### PR TITLE
[FF-05] 카카오맵 API를 이용해 자신을 기준으로 주변 음식점 검색

### DIFF
--- a/backend/src/main/java/com/mukkebi/foodfinder/FoodFinderApplication.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/FoodFinderApplication.java
@@ -1,13 +1,16 @@
 package com.mukkebi.foodfinder;
 
+import com.mukkebi.foodfinder.core.api.config.KakaoMapProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableConfigurationProperties(KakaoMapProperties.class)
 public class FoodFinderApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/api/config/KakaoMapConfig.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/api/config/KakaoMapConfig.java
@@ -1,0 +1,24 @@
+package com.mukkebi.foodfinder.core.api.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class KakaoMapConfig {
+    private final KakaoMapProperties kakaoMapProperties;
+
+    @Bean
+    public RestTemplate kakaoRestTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setInterceptors(List.of((request, body, execution) -> {
+            request.getHeaders().set("Authorization", "KakaoAK " + kakaoMapProperties.key());
+            return execution.execute(request, body);
+        }));
+        return restTemplate;
+    }
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/api/config/KakaoMapProperties.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/api/config/KakaoMapProperties.java
@@ -1,0 +1,11 @@
+package com.mukkebi.foodfinder.core.api.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "kakao.api")
+public record KakaoMapProperties(
+        String key,
+        String baseUrl
+) {
+
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/api/config/RestTemplateConfig.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/api/config/RestTemplateConfig.java
@@ -1,0 +1,20 @@
+package com.mukkebi.foodfinder.core.api.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+
+@Configuration
+public class RestTemplateConfig {
+
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder builder) {
+        return builder
+                .connectTimeout(Duration.ofSeconds(5))
+                .readTimeout(Duration.ofSeconds(5))
+                .build();
+    }
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/api/controller/v1/RestaurantController.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/api/controller/v1/RestaurantController.java
@@ -1,0 +1,24 @@
+package com.mukkebi.foodfinder.core.api.controller.v1;
+
+import com.mukkebi.foodfinder.core.api.controller.v1.request.RestaurantSearchRequest;
+import com.mukkebi.foodfinder.core.api.controller.v1.response.RestaurantResponse;
+import com.mukkebi.foodfinder.core.domain.RestaurantService;
+import com.mukkebi.foodfinder.core.support.response.ApiResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class RestaurantController {
+    private final RestaurantService restaurantService;
+
+    @PostMapping("/api/v1/restaurants/search")
+    public ApiResult<RestaurantResponse> searchNearbyRestaurants(
+            @Validated @RequestBody RestaurantSearchRequest request
+    ) {
+        return ApiResult.success(restaurantService.searchNearbyRestaurants(request.latitude(), request.longitude(), request.radius()));
+    }
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/api/controller/v1/request/RestaurantSearchRequest.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/api/controller/v1/request/RestaurantSearchRequest.java
@@ -1,0 +1,20 @@
+package com.mukkebi.foodfinder.core.api.controller.v1.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+public record RestaurantSearchRequest(
+        @NotNull(message = "위도는 필수입니다")
+        Double latitude,
+
+        @NotNull(message = "경도는 필수입니다")
+        Double longitude,
+
+        @Min(value = 100, message = "최소 반경은 100미터입니다")
+        @Max(value = 500, message = "최대 반경은 500미터입니다")
+        Integer radius
+) {
+
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/api/controller/v1/response/KakaoPlaceResponse.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/api/controller/v1/response/KakaoPlaceResponse.java
@@ -1,0 +1,66 @@
+package com.mukkebi.foodfinder.core.api.controller.v1.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+
+import java.util.List;
+
+public record KakaoPlaceResponse(
+        Meta meta,
+        List<Document> documents
+) {
+    public record Meta(
+            @JsonProperty("total_count")
+            Integer totalCount,
+
+            @JsonProperty("pageable_count")
+            Integer pageableCount,
+
+            @JsonProperty("is_end")
+            Boolean isEnd
+    ) {
+        public boolean canFetch() {
+            return totalCount <= pageableCount;
+        }
+
+        public boolean isEmpty() {
+            return totalCount == 0 || pageableCount == 0;
+        }
+
+        public Boolean isEnd() {
+            return isEnd;
+        }
+    }
+
+    public record Document(
+            String id,
+
+            @JsonProperty("place_name")
+            String placeName,
+
+            @JsonProperty("category_name")
+            String categoryName,
+
+            @JsonProperty("phone")
+            String phone,
+
+            @JsonProperty("address_name")
+            String addressName,
+
+            @JsonProperty("road_address_name")
+            String roadAddressName,
+
+            @JsonProperty("x")
+            String longitude,
+
+            @JsonProperty("y")
+            String latitude,
+
+            @JsonProperty("place_url")
+            String placeUrl,
+
+            String distance
+    ) {
+
+    }
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/api/controller/v1/response/RestaurantResponse.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/api/controller/v1/response/RestaurantResponse.java
@@ -1,0 +1,19 @@
+package com.mukkebi.foodfinder.core.api.controller.v1.response;
+
+import com.mukkebi.foodfinder.core.domain.Restaurant;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record RestaurantResponse(
+        List<Restaurant> restaurants
+) {
+
+    public static RestaurantResponse from(List<KakaoPlaceResponse.Document> documents) {
+        return new RestaurantResponse(
+                documents.stream()
+                        .map(Restaurant::from)
+                        .collect(Collectors.toList())
+        );
+    }
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/domain/Restaurant.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/domain/Restaurant.java
@@ -1,0 +1,33 @@
+package com.mukkebi.foodfinder.core.domain;
+
+import com.mukkebi.foodfinder.core.api.controller.v1.response.KakaoPlaceResponse;
+import lombok.Builder;
+
+@Builder
+public record Restaurant(
+        String id,
+        String name,
+        String category,
+        String phone,
+        String address,
+        String roadAddress,
+        Double latitude,
+        Double longitude,
+        Double distance,
+        String placeUrl
+) {
+    public static Restaurant from(KakaoPlaceResponse.Document document) {
+        return Restaurant.builder()
+                .id(document.id())
+                .name(document.placeName())
+                .category(document.categoryName())
+                .phone(document.phone())
+                .address(document.addressName())
+                .roadAddress(document.roadAddressName())
+                .latitude(Double.parseDouble(document.latitude()))
+                .longitude(Double.parseDouble(document.longitude()))
+                .distance(Double.parseDouble(document.distance()))
+                .placeUrl(document.placeUrl())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/domain/RestaurantService.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/domain/RestaurantService.java
@@ -1,0 +1,244 @@
+package com.mukkebi.foodfinder.core.domain;
+
+import com.mukkebi.foodfinder.core.api.config.KakaoMapProperties;
+import com.mukkebi.foodfinder.core.api.controller.v1.response.KakaoPlaceResponse;
+import com.mukkebi.foodfinder.core.api.controller.v1.response.RestaurantResponse;
+import com.mukkebi.foodfinder.core.support.constances.KakaoMapConstance;
+import com.mukkebi.foodfinder.core.support.error.CoreException;
+import com.mukkebi.foodfinder.core.support.error.ErrorType;
+import com.mukkebi.foodfinder.core.support.utils.CoordinateUtils;
+import com.mukkebi.foodfinder.core.support.utils.RectangleBounds;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RestaurantService {
+    private final RestTemplate kakaoRestTemplate;
+    private final KakaoMapProperties kakaoMapProperties;
+    private static final ThreadLocal<Integer> apiCallCounter = ThreadLocal.withInitial(() -> 0);
+
+    /**
+     * 위도, 경도 기준 주변에 있는 음식점 검색
+     *
+     * @param latitude  위도
+     * @param longitude 경도
+     * @param radius    범위
+     */
+    public RestaurantResponse searchNearbyRestaurants(Double latitude, Double longitude, Integer radius) {
+        apiCallCounter.set(0);
+
+        try {
+            Map<String, Restaurant> restaurants = new HashMap<>();
+
+            // Radius로 초기 검색
+            KakaoPlaceResponse initResponse = searchByRadius(latitude, longitude, radius);
+            if (initResponse.meta().canFetch()) {
+                List<Restaurant> result = searchByRadiusRestaurants(latitude, longitude, radius);
+                return new RestaurantResponse(filterAndSortByDistance(result, radius));
+            }
+
+            // Rect로 추가 검색
+            RectangleBounds initialBounds = CoordinateUtils.calculateRectangleBounds(latitude, longitude, radius);
+            searchByRectangleRecursive(latitude, longitude, initialBounds, restaurants, KakaoMapConstance.MAX_SUBDIVISION_CELL_SIZE);
+
+            return new RestaurantResponse(filterAndSortByDistance(restaurants.values().stream().toList(), radius));
+        } finally {
+            int totalApiCalls = apiCallCounter.get();
+            log.info("총 API 호출 횟수: {}회", totalApiCalls);
+            apiCallCounter.remove();
+        }
+
+    }
+
+    /**
+     * 1페이지만 주변 탐색 및 범위로 정렬
+     *
+     * @param latitude  경도
+     * @param longitude 위도
+     * @param radius    범위
+     */
+    private KakaoPlaceResponse searchByRadius(Double latitude, Double longitude, Integer radius) {
+        String url = UriComponentsBuilder
+                .fromHttpUrl(kakaoMapProperties.baseUrl() + "/v2/local/search/category.json")
+                .queryParam("category_group_code", KakaoMapConstance.CATEGORY_GROUP_CODE)
+                .queryParam("x", longitude)
+                .queryParam("y", latitude)
+                .queryParam("radius", radius)
+                .queryParam("size", KakaoMapConstance.PAGE_SIZE)
+                .queryParam("page", 1)
+                .queryParam("sort", "distance")
+                .build()
+                .toUriString();
+
+        return executeApiCall(url);
+    }
+
+    /**
+     * 주변에 있는 음식점 전부 조회
+     *
+     * @param latitude  경도
+     * @param longitude 위도
+     * @param radius    범위
+     */
+    private List<Restaurant> searchByRadiusRestaurants(Double latitude, Double longitude, Integer radius) {
+        List<Restaurant> restaurants = new ArrayList<>();
+
+        for (int page = 1; page <= KakaoMapConstance.PAGE_SIZE; page++) {
+            String url = UriComponentsBuilder
+                    .fromHttpUrl(kakaoMapProperties.baseUrl() + "/v2/local/search/category.json")
+                    .queryParam("category_group_code", KakaoMapConstance.CATEGORY_GROUP_CODE)
+                    .queryParam("x", longitude)
+                    .queryParam("y", latitude)
+                    .queryParam("radius", radius)
+                    .queryParam("size", KakaoMapConstance.PAGE_SIZE)
+                    .queryParam("page", page)
+                    .queryParam("sort", "distance")
+                    .build()
+                    .toUriString();
+
+            KakaoPlaceResponse response = executeApiCall(url);
+            restaurants.addAll(
+                    response.documents().stream()
+                            .map(Restaurant::from)
+                            .toList()
+            );
+
+            if (response.meta().isEnd()) {
+                break;
+            }
+        }
+
+        return restaurants;
+    }
+
+    /**
+     * 재귀 적으로 사각형을 4등분하여 검색
+     *
+     * @param latitude    위도
+     * @param longitude   경도
+     * @param bounds      사각형 크기 (위도, 경도 기반)
+     * @param restaurants 음식점 저장 Map(PlaceId, 음식점)
+     * @param size        이전 사각형 크기
+     */
+    private void searchByRectangleRecursive(Double latitude, Double longitude, RectangleBounds bounds, Map<String, Restaurant> restaurants, int size) {
+
+        KakaoPlaceResponse response = searchByRectangle(latitude, longitude, bounds);
+        if (response.meta().canFetch()) {
+            searchByRectangleRestaurants(latitude, longitude, bounds).forEach(restaurant -> restaurants.putIfAbsent(restaurant.id(), restaurant));
+            return;
+        }
+
+        if (response.meta().isEmpty()) {
+            return;
+        }
+
+        if (size < KakaoMapConstance.MIN_SUBDIVISION_CELL_SIZE) {
+            searchByRectangleRestaurants(latitude, longitude, bounds).forEach(restaurant -> restaurants.putIfAbsent(restaurant.id(), restaurant));
+            return;
+        }
+
+        RectangleBounds[] subRectangles = CoordinateUtils.subdivideRectangle(bounds);
+        for (RectangleBounds subRect : subRectangles) {
+            searchByRectangleRecursive(latitude, longitude, subRect, restaurants, size / 2);
+        }
+    }
+
+    /**
+     * 1페이지만 사각형안에 있는 음식점 조회
+     *
+     * @param latitude  경도
+     * @param longitude 위도
+     * @param bounds    사각형 크기 (위도, 경도 기반)
+     */
+    private KakaoPlaceResponse searchByRectangle(Double latitude, Double longitude, RectangleBounds bounds) {
+        String url = UriComponentsBuilder
+                .fromHttpUrl(kakaoMapProperties.baseUrl() + "/v2/local/search/category.json")
+                .queryParam("category_group_code", KakaoMapConstance.CATEGORY_GROUP_CODE)
+                .queryParam("x", longitude)
+                .queryParam("y", latitude)
+                .queryParam("rect", bounds.toRectParameter())
+                .queryParam("size", KakaoMapConstance.PAGE_SIZE)
+                .queryParam("page", 1)
+                .queryParam("sort", "distance")
+                .build()
+                .toUriString();
+
+        return executeApiCall(url);
+    }
+
+    /**
+     * 사각형안에 있는 모든 음식점 조회
+     *
+     * @param latitude  경도
+     * @param longitude 위도
+     * @param bounds    사각형 크기 (위도, 경도 기반)
+     */
+    private List<Restaurant> searchByRectangleRestaurants(Double latitude, Double longitude, RectangleBounds bounds) {
+        List<Restaurant> restaurants = new ArrayList<>();
+
+        for (int page = 1; page <= KakaoMapConstance.PAGE_SIZE; page++) {
+            String url = UriComponentsBuilder
+                    .fromHttpUrl(kakaoMapProperties.baseUrl() + "/v2/local/search/category.json")
+                    .queryParam("category_group_code", KakaoMapConstance.CATEGORY_GROUP_CODE)
+                    .queryParam("x", longitude)
+                    .queryParam("y", latitude)
+                    .queryParam("rect", bounds.toRectParameter())
+                    .queryParam("size", KakaoMapConstance.PAGE_SIZE)
+                    .queryParam("page", page)
+                    .queryParam("sort", "distance")
+                    .build()
+                    .toUriString();
+
+            KakaoPlaceResponse response = executeApiCall(url);
+            restaurants.addAll(
+                    response.documents().stream()
+                            .map(Restaurant::from)
+                            .toList()
+            );
+
+            if (response.meta().isEnd()) {
+                break;
+            }
+        }
+
+        return restaurants;
+    }
+
+    /**
+     * Kakao Map API 호출
+     *
+     * @param url 호출할 url
+     */
+    private KakaoPlaceResponse executeApiCall(String url) {
+        try {
+            apiCallCounter.set(apiCallCounter.get() + 1);
+            ResponseEntity<KakaoPlaceResponse> response = kakaoRestTemplate.getForEntity(url, KakaoPlaceResponse.class);
+            return response.getBody();
+        } catch (Exception e) {
+            log.error("카카오 API 호출 실패: {}", e.getMessage(), e);
+            throw new CoreException(ErrorType.DEFAULT_ERROR);
+        }
+    }
+
+    /**
+     * 범위보다 긴 거리는 제외하고 거리순으로 정렬
+     *
+     * @param restaurants 음식점들
+     * @param radius      범위
+     */
+    private List<Restaurant> filterAndSortByDistance(List<Restaurant> restaurants, int radius) {
+        return restaurants.stream()
+                .filter(r -> r.distance() <= radius)
+                .sorted(Comparator.comparingDouble(Restaurant::distance))
+                .collect(Collectors.toList());
+    }
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/support/constances/KakaoMapConstance.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/support/constances/KakaoMapConstance.java
@@ -1,0 +1,20 @@
+package com.mukkebi.foodfinder.core.support.constances;
+
+public class KakaoMapConstance {
+
+    // 카카오맵 음식점 카테고리
+    public static final String  CATEGORY_GROUP_CODE = "FD6";
+
+    // 최소 분할 단위 (100 -> 50 -> 25)
+    public static final int     MAX_SUBDIVISION_CELL_SIZE = 100;
+    public static final int     MIN_SUBDIVISION_CELL_SIZE = 25;
+
+    // 한번에 보여주는 음식점 개수
+    public static final int     PAGE_SIZE = 15;
+
+    // 45 = 15 * 3으로 API 가져와야함
+    public static final int     MAX_PAGE = 3;
+
+    private KakaoMapConstance() {
+    }
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/support/utils/CoordinateUtils.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/support/utils/CoordinateUtils.java
@@ -1,0 +1,35 @@
+package com.mukkebi.foodfinder.core.support.utils;
+
+public class CoordinateUtils {
+    private static final double METERS_PER_DEGREE_LAT = 111320.0;
+
+    /**
+     * 중심점과 반경을 기준으로 사각형 경계를 계산합니다
+     */
+    public static RectangleBounds calculateRectangleBounds(double centerLat, double centerLon, int radiusMeters) {
+        double latDelta = radiusMeters / METERS_PER_DEGREE_LAT;
+        double lonDelta = radiusMeters / (METERS_PER_DEGREE_LAT * Math.cos(Math.toRadians(centerLat)));
+
+        return new RectangleBounds(
+                centerLat - latDelta,
+                centerLat + latDelta,
+                centerLon - lonDelta,
+                centerLon + lonDelta
+        );
+    }
+
+    /**
+     * 사각형을 4개의 작은 사각형으로 분할합니다
+     */
+    public static RectangleBounds[] subdivideRectangle(RectangleBounds bounds) {
+        double midLat = (bounds.getMinLatitude() + bounds.getMaxLatitude()) / 2;
+        double midLon = (bounds.getMinLongitude() + bounds.getMaxLongitude()) / 2;
+
+        return new RectangleBounds[] {
+                new RectangleBounds(bounds.getMinLatitude(), midLat, bounds.getMinLongitude(), midLon),
+                new RectangleBounds(bounds.getMinLatitude(), midLat, midLon, bounds.getMaxLongitude()),
+                new RectangleBounds(midLat, bounds.getMaxLatitude(), bounds.getMinLongitude(), midLon),
+                new RectangleBounds(midLat, bounds.getMaxLatitude(), midLon, bounds.getMaxLongitude())
+        };
+    }
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/support/utils/RectangleBounds.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/support/utils/RectangleBounds.java
@@ -1,0 +1,18 @@
+package com.mukkebi.foodfinder.core.support.utils;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RectangleBounds {
+    private double minLatitude;
+    private double maxLatitude;
+    private double minLongitude;
+    private double maxLongitude;
+
+    public String toRectParameter() {
+        return String.format("%f,%f,%f,%f",
+                minLongitude, minLatitude, maxLongitude, maxLatitude);
+    }
+}


### PR DESCRIPTION
## 개요

카카오맵 API를 이용해서 위도 경도를 기준으로 주변의 음식점들을 조회

## 작업 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 (test)
- [ ] 빌드/설정 (build)
- [ ] 기타 (chore)

## 변경 사항

- 카카오맵 API 연결
- 카카오맵을 이용해 자신의 주변 음식점 조회

## 테스트 여부

- [x] postman조회 테스트

## 참고 사항

테스트하고 싶다면 해당 body를 이용하여 테스트
```
{
  "latitude": 37.48645493735768,
  "longitude": 127.02069449028099,
  "radius": 100
}

radius 100~300으로할것 500은 API소모가 큼

```

## 스크린샷 (선택)

<img width="891" height="868" alt="{71C95F08-3D4D-4354-BFD8-B780A9525871}" src="https://github.com/user-attachments/assets/1a61b7cc-9cf0-4d1a-94ea-f87d66f8ad24" />
