### PR TITLE
[FF-04] Github로 로그인 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -45,6 +45,9 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // OAuth2 login
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/api/config/SecurityConfig.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/api/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.mukkebi.foodfinder.core.api.config;
+
+import com.mukkebi.foodfinder.core.domain.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/", "/login/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth -> oauth
+                        .userInfoEndpoint(user ->
+                                user.userService(customOAuth2UserService)
+                        )
+                );
+
+        return http.build();
+    }
+}
+

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/api/controller/v1/UserController.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/api/controller/v1/UserController.java
@@ -1,0 +1,29 @@
+package com.mukkebi.foodfinder.core.api.controller.v1;
+
+import com.mukkebi.foodfinder.core.support.response.ApiResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    // 로그인 성공 메세지 API
+    @GetMapping("/api/users/login-success")
+    public ApiResult<String> loginSuccess() {
+        return ApiResult.success("GitHub 로그인 성공!");
+    }
+
+    // 로그인한 사용자의 GitHub 정보 조회 API
+    @GetMapping("/github-profile")
+    public ApiResult<Map<String, Object>> githubProfile(
+            @AuthenticationPrincipal OAuth2User oauth2User
+    ) {
+        return ApiResult.success(oauth2User.getAttributes());
+    }
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/domain/CustomOAuth2UserService.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/domain/CustomOAuth2UserService.java
@@ -1,0 +1,38 @@
+package com.mukkebi.foodfinder.core.domain;
+
+import com.mukkebi.foodfinder.storage.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest)
+            throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        Long githubId = Long.valueOf(oAuth2User.getAttribute("id").toString());
+        String login = oAuth2User.getAttribute("login");
+
+        // DB에 User가 이미 있으면 조회, 없으면 새로 생성
+        User user = userRepository.findByGithubId(githubId.toString())
+                .orElseGet(() -> {
+                    User newUser = User.builder()
+                            .githubId(githubId.toString())
+                            .nickname(login)
+                            .build();
+                    return userRepository.save(newUser);
+                });
+
+        return oAuth2User;
+    }
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/domain/User.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/domain/User.java
@@ -1,0 +1,30 @@
+package com.mukkebi.foodfinder.core.domain;
+
+import com.mukkebi.foodfinder.storage.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+public class User extends BaseEntity {
+
+    @Column(nullable = false, unique = true)
+    private String githubId;
+
+    @Column(nullable = false)
+    private String nickname;
+
+    @Builder
+    public User(String githubId, String nickname) {
+        this.githubId = githubId;
+        this.nickname = nickname;
+    }
+}
+

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/domain/User.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/domain/User.java
@@ -15,10 +15,10 @@ import lombok.NoArgsConstructor;
 @Table(name = "users")
 public class User extends BaseEntity {
 
-    @Column(nullable = false, unique = true)
+    @Column(name = "github_id", nullable = false, unique = true)
     private String githubId;
 
-    @Column(nullable = false)
+    @Column(name = "nickname", nullable = false)
     private String nickname;
 
     @Builder

--- a/backend/src/main/java/com/mukkebi/foodfinder/storage/UserRepository.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/storage/UserRepository.java
@@ -1,0 +1,12 @@
+package com.mukkebi.foodfinder.storage;
+
+import com.mukkebi.foodfinder.core.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByGithubId(String githubId);
+}
+


### PR DESCRIPTION
## 개요

사용자가 Github 아이디로 서비스에 로그인


## 작업 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [ ] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [ ] 테스트 (test)
- [x] 빌드/설정 (build)
- [ ] 기타 (chore)

## 변경 사항

- GitHub OAuth2를 이용한 로그인 기능 구현
- 최초 로그인 시 GitHub 계정 정보를 기반으로 User 자동 생성
- Github 키를 발급받아 application-local.yml 파일에 저장
- 로그인 확인 테스트용 api 구현

## 테스트 여부

- [x] 로컬에서 테스트 완료


## 참고 사항

`/oauth2/authorization/github` 경로로 접속하여 GitHub 로그인 가능

## 스크린샷 (선택)

<img width="500" alt="화면 캡처 2025-12-23 115151" src="https://github.com/user-attachments/assets/77e3d540-e694-4319-b65e-6dc6fb6f74d1" />
<img width="459" height="70" alt="화면 캡처 2025-12-23 121109" src="https://github.com/user-attachments/assets/35a1264b-d567-4a96-bf1b-d3365c02f238" />

