### PR TITLE
[FF-09] 카카오맵 API 계층 분리

### DIFF
--- a/backend/src/main/java/com/mukkebi/foodfinder/core/api/controller/v1/response/RestaurantResponse.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/api/controller/v1/response/RestaurantResponse.java
@@ -3,17 +3,9 @@ package com.mukkebi.foodfinder.core.api.controller.v1.response;
 import com.mukkebi.foodfinder.core.domain.Restaurant;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 public record RestaurantResponse(
         List<Restaurant> restaurants
 ) {
 
-    public static RestaurantResponse from(List<KakaoPlaceResponse.Document> documents) {
-        return new RestaurantResponse(
-                documents.stream()
-                        .map(Restaurant::from)
-                        .collect(Collectors.toList())
-        );
-    }
 }

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/domain/RestaurantFinder.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/domain/RestaurantFinder.java
@@ -1,0 +1,7 @@
+package com.mukkebi.foodfinder.core.domain;
+
+import java.util.List;
+
+public interface RestaurantFinder {
+    List<Restaurant> findNearBy(Double latitude, Double longitude, Integer radius);
+}

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/domain/RestaurantService.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/domain/RestaurantService.java
@@ -1,30 +1,17 @@
 package com.mukkebi.foodfinder.core.domain;
 
-import com.mukkebi.foodfinder.core.api.config.KakaoMapProperties;
-import com.mukkebi.foodfinder.core.api.controller.v1.response.KakaoPlaceResponse;
 import com.mukkebi.foodfinder.core.api.controller.v1.response.RestaurantResponse;
-import com.mukkebi.foodfinder.core.support.constances.KakaoMapConstance;
-import com.mukkebi.foodfinder.core.support.error.CoreException;
-import com.mukkebi.foodfinder.core.support.error.ErrorType;
-import com.mukkebi.foodfinder.core.support.utils.CoordinateUtils;
-import com.mukkebi.foodfinder.core.support.utils.RectangleBounds;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.List;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class RestaurantService {
-    private final RestTemplate kakaoRestTemplate;
-    private final KakaoMapProperties kakaoMapProperties;
-    private static final ThreadLocal<Integer> apiCallCounter = ThreadLocal.withInitial(() -> 0);
+    private final RestaurantFinder restaurantFinder;
 
     /**
      * 위도, 경도 기준 주변에 있는 음식점 검색
@@ -34,211 +21,9 @@ public class RestaurantService {
      * @param radius    범위
      */
     public RestaurantResponse searchNearbyRestaurants(Double latitude, Double longitude, Integer radius) {
-        apiCallCounter.set(0);
 
-        try {
-            Map<String, Restaurant> restaurants = new HashMap<>();
-
-            // Radius로 초기 검색
-            KakaoPlaceResponse initResponse = searchByRadius(latitude, longitude, radius);
-            if (initResponse.meta().canFetch()) {
-                List<Restaurant> result = searchByRadiusRestaurants(latitude, longitude, radius);
-                return new RestaurantResponse(filterAndSortByDistance(result, radius));
-            }
-
-            // Rect로 추가 검색
-            RectangleBounds initialBounds = CoordinateUtils.calculateRectangleBounds(latitude, longitude, radius);
-            searchByRectangleRecursive(latitude, longitude, initialBounds, restaurants, KakaoMapConstance.MAX_SUBDIVISION_CELL_SIZE);
-
-            return new RestaurantResponse(filterAndSortByDistance(restaurants.values().stream().toList(), radius));
-        } finally {
-            int totalApiCalls = apiCallCounter.get();
-            log.info("총 API 호출 횟수: {}회", totalApiCalls);
-            apiCallCounter.remove();
-        }
-
-    }
-
-    /**
-     * 1페이지만 주변 탐색 및 범위로 정렬
-     *
-     * @param latitude  경도
-     * @param longitude 위도
-     * @param radius    범위
-     */
-    private KakaoPlaceResponse searchByRadius(Double latitude, Double longitude, Integer radius) {
-        String url = UriComponentsBuilder
-                .fromHttpUrl(kakaoMapProperties.baseUrl() + "/v2/local/search/category.json")
-                .queryParam("category_group_code", KakaoMapConstance.CATEGORY_GROUP_CODE)
-                .queryParam("x", longitude)
-                .queryParam("y", latitude)
-                .queryParam("radius", radius)
-                .queryParam("size", KakaoMapConstance.PAGE_SIZE)
-                .queryParam("page", 1)
-                .queryParam("sort", "distance")
-                .build()
-                .toUriString();
-
-        return executeApiCall(url);
-    }
-
-    /**
-     * 주변에 있는 음식점 전부 조회
-     *
-     * @param latitude  경도
-     * @param longitude 위도
-     * @param radius    범위
-     */
-    private List<Restaurant> searchByRadiusRestaurants(Double latitude, Double longitude, Integer radius) {
-        List<Restaurant> restaurants = new ArrayList<>();
-
-        for (int page = 1; page <= KakaoMapConstance.PAGE_SIZE; page++) {
-            String url = UriComponentsBuilder
-                    .fromHttpUrl(kakaoMapProperties.baseUrl() + "/v2/local/search/category.json")
-                    .queryParam("category_group_code", KakaoMapConstance.CATEGORY_GROUP_CODE)
-                    .queryParam("x", longitude)
-                    .queryParam("y", latitude)
-                    .queryParam("radius", radius)
-                    .queryParam("size", KakaoMapConstance.PAGE_SIZE)
-                    .queryParam("page", page)
-                    .queryParam("sort", "distance")
-                    .build()
-                    .toUriString();
-
-            KakaoPlaceResponse response = executeApiCall(url);
-            restaurants.addAll(
-                    response.documents().stream()
-                            .map(Restaurant::from)
-                            .toList()
-            );
-
-            if (response.meta().isEnd()) {
-                break;
-            }
-        }
-
-        return restaurants;
-    }
-
-    /**
-     * 재귀 적으로 사각형을 4등분하여 검색
-     *
-     * @param latitude    위도
-     * @param longitude   경도
-     * @param bounds      사각형 크기 (위도, 경도 기반)
-     * @param restaurants 음식점 저장 Map(PlaceId, 음식점)
-     * @param size        이전 사각형 크기
-     */
-    private void searchByRectangleRecursive(Double latitude, Double longitude, RectangleBounds bounds, Map<String, Restaurant> restaurants, int size) {
-
-        KakaoPlaceResponse response = searchByRectangle(latitude, longitude, bounds);
-        if (response.meta().canFetch()) {
-            searchByRectangleRestaurants(latitude, longitude, bounds).forEach(restaurant -> restaurants.putIfAbsent(restaurant.id(), restaurant));
-            return;
-        }
-
-        if (response.meta().isEmpty()) {
-            return;
-        }
-
-        if (size < KakaoMapConstance.MIN_SUBDIVISION_CELL_SIZE) {
-            searchByRectangleRestaurants(latitude, longitude, bounds).forEach(restaurant -> restaurants.putIfAbsent(restaurant.id(), restaurant));
-            return;
-        }
-
-        RectangleBounds[] subRectangles = CoordinateUtils.subdivideRectangle(bounds);
-        for (RectangleBounds subRect : subRectangles) {
-            searchByRectangleRecursive(latitude, longitude, subRect, restaurants, size / 2);
-        }
-    }
-
-    /**
-     * 1페이지만 사각형안에 있는 음식점 조회
-     *
-     * @param latitude  경도
-     * @param longitude 위도
-     * @param bounds    사각형 크기 (위도, 경도 기반)
-     */
-    private KakaoPlaceResponse searchByRectangle(Double latitude, Double longitude, RectangleBounds bounds) {
-        String url = UriComponentsBuilder
-                .fromHttpUrl(kakaoMapProperties.baseUrl() + "/v2/local/search/category.json")
-                .queryParam("category_group_code", KakaoMapConstance.CATEGORY_GROUP_CODE)
-                .queryParam("x", longitude)
-                .queryParam("y", latitude)
-                .queryParam("rect", bounds.toRectParameter())
-                .queryParam("size", KakaoMapConstance.PAGE_SIZE)
-                .queryParam("page", 1)
-                .queryParam("sort", "distance")
-                .build()
-                .toUriString();
-
-        return executeApiCall(url);
-    }
-
-    /**
-     * 사각형안에 있는 모든 음식점 조회
-     *
-     * @param latitude  경도
-     * @param longitude 위도
-     * @param bounds    사각형 크기 (위도, 경도 기반)
-     */
-    private List<Restaurant> searchByRectangleRestaurants(Double latitude, Double longitude, RectangleBounds bounds) {
-        List<Restaurant> restaurants = new ArrayList<>();
-
-        for (int page = 1; page <= KakaoMapConstance.PAGE_SIZE; page++) {
-            String url = UriComponentsBuilder
-                    .fromHttpUrl(kakaoMapProperties.baseUrl() + "/v2/local/search/category.json")
-                    .queryParam("category_group_code", KakaoMapConstance.CATEGORY_GROUP_CODE)
-                    .queryParam("x", longitude)
-                    .queryParam("y", latitude)
-                    .queryParam("rect", bounds.toRectParameter())
-                    .queryParam("size", KakaoMapConstance.PAGE_SIZE)
-                    .queryParam("page", page)
-                    .queryParam("sort", "distance")
-                    .build()
-                    .toUriString();
-
-            KakaoPlaceResponse response = executeApiCall(url);
-            restaurants.addAll(
-                    response.documents().stream()
-                            .map(Restaurant::from)
-                            .toList()
-            );
-
-            if (response.meta().isEnd()) {
-                break;
-            }
-        }
-
-        return restaurants;
-    }
-
-    /**
-     * Kakao Map API 호출
-     *
-     * @param url 호출할 url
-     */
-    private KakaoPlaceResponse executeApiCall(String url) {
-        try {
-            apiCallCounter.set(apiCallCounter.get() + 1);
-            ResponseEntity<KakaoPlaceResponse> response = kakaoRestTemplate.getForEntity(url, KakaoPlaceResponse.class);
-            return response.getBody();
-        } catch (Exception e) {
-            log.error("카카오 API 호출 실패: {}", e.getMessage(), e);
-            throw new CoreException(ErrorType.DEFAULT_ERROR);
-        }
-    }
-
-    /**
-     * 범위보다 긴 거리는 제외하고 거리순으로 정렬
-     *
-     * @param restaurants 음식점들
-     * @param radius      범위
-     */
-    private List<Restaurant> filterAndSortByDistance(List<Restaurant> restaurants, int radius) {
-        return restaurants.stream()
-                .filter(r -> r.distance() <= radius)
-                .sorted(Comparator.comparingDouble(Restaurant::distance))
-                .collect(Collectors.toList());
+        // 주변에 있는 음식점 조회
+        List<Restaurant> restaurants = restaurantFinder.findNearBy(latitude, longitude, radius);
+        return new RestaurantResponse(restaurants);
     }
 }

--- a/backend/src/main/java/com/mukkebi/foodfinder/core/infra/KakaoMapRestaurantFinder.java
+++ b/backend/src/main/java/com/mukkebi/foodfinder/core/infra/KakaoMapRestaurantFinder.java
@@ -1,0 +1,237 @@
+package com.mukkebi.foodfinder.core.infra;
+
+import com.mukkebi.foodfinder.core.api.config.KakaoMapProperties;
+import com.mukkebi.foodfinder.core.api.controller.v1.response.KakaoPlaceResponse;
+import com.mukkebi.foodfinder.core.domain.Restaurant;
+import com.mukkebi.foodfinder.core.domain.RestaurantFinder;
+import com.mukkebi.foodfinder.core.support.constances.KakaoMapConstance;
+import com.mukkebi.foodfinder.core.support.error.CoreException;
+import com.mukkebi.foodfinder.core.support.error.ErrorType;
+import com.mukkebi.foodfinder.core.support.utils.CoordinateUtils;
+import com.mukkebi.foodfinder.core.support.utils.RectangleBounds;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.util.*;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class KakaoMapRestaurantFinder implements RestaurantFinder {
+    private final RestTemplate kakaoRestTemplate;
+    private final KakaoMapProperties kakaoMapProperties;
+    private static final ThreadLocal<Integer> apiCallCounter = ThreadLocal.withInitial(() -> 0);
+
+    @Override
+    public List<Restaurant> findNearBy(Double latitude, Double longitude, Integer radius) {
+        apiCallCounter.set(0);
+
+        try {
+            Map<String, Restaurant> restaurants = new HashMap<>();
+
+            // Radius로 초기 검색
+            KakaoPlaceResponse initResponse = searchByRadius(latitude, longitude, radius);
+            if (initResponse.meta().canFetch()) {
+                List<Restaurant> result = searchByRadiusRestaurants(latitude, longitude, radius);
+                return filterAndSortByDistance(result, radius);
+            }
+
+            // Rect로 추가 검색
+            RectangleBounds initialBounds = CoordinateUtils.calculateRectangleBounds(latitude, longitude, radius);
+            searchByRectangleRecursive(latitude, longitude, initialBounds, restaurants, KakaoMapConstance.MAX_SUBDIVISION_CELL_SIZE);
+
+            return filterAndSortByDistance(restaurants.values().stream().toList(), radius);
+        } finally {
+            int totalApiCalls = apiCallCounter.get();
+            log.info("총 API 호출 횟수: {}회", totalApiCalls);
+            apiCallCounter.remove();
+        }
+    }
+
+    /**
+     * 1페이지만 주변 탐색 및 범위로 정렬
+     *
+     * @param latitude  위도
+     * @param longitude 경도
+     * @param radius    범위
+     */
+    private KakaoPlaceResponse searchByRadius(Double latitude, Double longitude, Integer radius) {
+        String url = UriComponentsBuilder
+                .fromHttpUrl(kakaoMapProperties.baseUrl() + "/v2/local/search/category.json")
+                .queryParam("category_group_code", KakaoMapConstance.CATEGORY_GROUP_CODE)
+                .queryParam("x", longitude)
+                .queryParam("y", latitude)
+                .queryParam("radius", radius)
+                .queryParam("size", KakaoMapConstance.PAGE_SIZE)
+                .queryParam("page", 1)
+                .queryParam("sort", "distance")
+                .build()
+                .toUriString();
+
+        return executeApiCall(url);
+    }
+
+    /**
+     * 주변에 있는 음식점 전부 조회
+     *
+     * @param latitude  위도
+     * @param longitude 경도
+     * @param radius    범위
+     */
+    private List<Restaurant> searchByRadiusRestaurants(Double latitude, Double longitude, Integer radius) {
+        List<Restaurant> restaurants = new ArrayList<>();
+
+        for (int page = 1; page <= KakaoMapConstance.PAGE_SIZE; page++) {
+            String url = UriComponentsBuilder
+                    .fromHttpUrl(kakaoMapProperties.baseUrl() + "/v2/local/search/category.json")
+                    .queryParam("category_group_code", KakaoMapConstance.CATEGORY_GROUP_CODE)
+                    .queryParam("x", longitude)
+                    .queryParam("y", latitude)
+                    .queryParam("radius", radius)
+                    .queryParam("size", KakaoMapConstance.PAGE_SIZE)
+                    .queryParam("page", page)
+                    .queryParam("sort", "distance")
+                    .build()
+                    .toUriString();
+
+            KakaoPlaceResponse response = executeApiCall(url);
+            restaurants.addAll(
+                    response.documents().stream()
+                            .map(Restaurant::from)
+                            .toList()
+            );
+
+            if (response.meta().isEnd()) {
+                break;
+            }
+        }
+
+        return restaurants;
+    }
+
+    /**
+     * 재귀 적으로 사각형을 4등분하여 검색
+     *
+     * @param latitude    위도
+     * @param longitude   경도
+     * @param bounds      사각형 크기 (위도, 경도 기반)
+     * @param restaurants 음식점 저장 Map(PlaceId, 음식점)
+     * @param size        이전 사각형 크기
+     */
+    private void searchByRectangleRecursive(Double latitude, Double longitude, RectangleBounds bounds, Map<String, Restaurant> restaurants, int size) {
+
+        KakaoPlaceResponse response = searchByRectangle(latitude, longitude, bounds);
+        if (response.meta().canFetch()) {
+            searchByRectangleRestaurants(latitude, longitude, bounds).forEach(restaurant -> restaurants.putIfAbsent(restaurant.id(), restaurant));
+            return;
+        }
+
+        if (response.meta().isEmpty()) {
+            return;
+        }
+
+        if (size < KakaoMapConstance.MIN_SUBDIVISION_CELL_SIZE) {
+            searchByRectangleRestaurants(latitude, longitude, bounds).forEach(restaurant -> restaurants.putIfAbsent(restaurant.id(), restaurant));
+            return;
+        }
+
+        RectangleBounds[] subRectangles = CoordinateUtils.subdivideRectangle(bounds);
+        for (RectangleBounds subRect : subRectangles) {
+            searchByRectangleRecursive(latitude, longitude, subRect, restaurants, size / 2);
+        }
+    }
+
+    /**
+     * 1페이지만 사각형안에 있는 음식점 조회
+     *
+     * @param latitude  위도
+     * @param longitude 경도
+     * @param bounds    사각형 크기 (위도, 경도 기반)
+     */
+    private KakaoPlaceResponse searchByRectangle(Double latitude, Double longitude, RectangleBounds bounds) {
+        String url = UriComponentsBuilder
+                .fromHttpUrl(kakaoMapProperties.baseUrl() + "/v2/local/search/category.json")
+                .queryParam("category_group_code", KakaoMapConstance.CATEGORY_GROUP_CODE)
+                .queryParam("x", longitude)
+                .queryParam("y", latitude)
+                .queryParam("rect", bounds.toRectParameter())
+                .queryParam("size", KakaoMapConstance.PAGE_SIZE)
+                .queryParam("page", 1)
+                .queryParam("sort", "distance")
+                .build()
+                .toUriString();
+
+        return executeApiCall(url);
+    }
+
+    /**
+     * 사각형안에 있는 모든 음식점 조회
+     *
+     * @param latitude  위도
+     * @param longitude 경도
+     * @param bounds    사각형 크기 (위도, 경도 기반)
+     */
+    private List<Restaurant> searchByRectangleRestaurants(Double latitude, Double longitude, RectangleBounds bounds) {
+        List<Restaurant> restaurants = new ArrayList<>();
+
+        for (int page = 1; page <= KakaoMapConstance.PAGE_SIZE; page++) {
+            String url = UriComponentsBuilder
+                    .fromHttpUrl(kakaoMapProperties.baseUrl() + "/v2/local/search/category.json")
+                    .queryParam("category_group_code", KakaoMapConstance.CATEGORY_GROUP_CODE)
+                    .queryParam("x", longitude)
+                    .queryParam("y", latitude)
+                    .queryParam("rect", bounds.toRectParameter())
+                    .queryParam("size", KakaoMapConstance.PAGE_SIZE)
+                    .queryParam("page", page)
+                    .queryParam("sort", "distance")
+                    .build()
+                    .toUriString();
+
+            KakaoPlaceResponse response = executeApiCall(url);
+            restaurants.addAll(
+                    response.documents().stream()
+                            .map(Restaurant::from)
+                            .toList()
+            );
+
+            if (response.meta().isEnd()) {
+                break;
+            }
+        }
+
+        return restaurants;
+    }
+
+    /**
+     * Kakao Map API 호출
+     *
+     * @param url 호출할 url
+     */
+    private KakaoPlaceResponse executeApiCall(String url) {
+        try {
+            apiCallCounter.set(apiCallCounter.get() + 1);
+            ResponseEntity<KakaoPlaceResponse> response = kakaoRestTemplate.getForEntity(url, KakaoPlaceResponse.class);
+            return response.getBody();
+        } catch (Exception e) {
+            log.error("카카오 API 호출 실패: {}", e.getMessage(), e);
+            throw new CoreException(ErrorType.DEFAULT_ERROR);
+        }
+    }
+
+    /**
+     * 범위보다 긴 거리는 제외하고 거리순으로 정렬
+     *
+     * @param restaurants 음식점들
+     * @param radius      범위
+     */
+    private List<Restaurant> filterAndSortByDistance(List<Restaurant> restaurants, int radius) {
+        return restaurants.stream()
+                .filter(r -> r.distance() <= radius)
+                .sorted(Comparator.comparingDouble(Restaurant::distance))
+                .toList();
+    }
+}

--- a/backend/src/test/java/com/mukkebi/foodfinder/core/domain/RestaurantServiceTests.java
+++ b/backend/src/test/java/com/mukkebi/foodfinder/core/domain/RestaurantServiceTests.java
@@ -1,0 +1,43 @@
+package com.mukkebi.foodfinder.core.domain;
+
+import com.mukkebi.foodfinder.core.api.controller.v1.response.RestaurantResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class RestaurantServiceTests {
+
+    @Mock
+    RestaurantFinder restaurantFinder;
+
+    @InjectMocks
+    RestaurantService restaurantService;
+
+    @Test
+    @DisplayName("주변 음식점을 조회")
+    void findNearByTest() {
+        //given
+        List<Restaurant> restaurants = List.of(
+                new Restaurant("1", "음식점1", "음식점 > 큰 카테고리 > 작은 카테고리", "010-1234-4567", "주소1", "도로명1", 37.123, 127.456, 100.0, "https://음식점1"),
+                new Restaurant("2", "음식점2", "음식점 > 큰 카테고리 > 작은 카테고리", "010-4567-1234", "주소2", "도로명2", 37.124, 127.457, 110.0, "https://음식점2")
+        );
+        given(restaurantFinder.findNearBy(37.0, 127.0, 500)).willReturn(restaurants);
+
+        //when
+        RestaurantResponse response = restaurantService.searchNearbyRestaurants(37.0, 127.0, 500);
+
+        //then
+        assertThat(response.restaurants()).hasSize(2);
+    }
+}

--- a/backend/src/test/java/com/mukkebi/foodfinder/core/integration/RestaurantIntegrationTests.java
+++ b/backend/src/test/java/com/mukkebi/foodfinder/core/integration/RestaurantIntegrationTests.java
@@ -1,0 +1,35 @@
+package com.mukkebi.foodfinder.core.integration;
+
+import com.mukkebi.foodfinder.core.infra.KakaoMapRestaurantFinder;
+import com.mukkebi.foodfinder.core.domain.Restaurant;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("local")
+@Disabled
+public class RestaurantIntegrationTests {
+
+    @Autowired
+    KakaoMapRestaurantFinder kakaoMapRestaurantFinder;
+
+    @Test
+    @DisplayName("카카오맵 API 호출 테스트")
+    void callKakaoMapRestaurantFinder() {
+        Double latitude = 37.48645493735768;
+        Double longitude = 127.02069449028099;
+        Integer radius = 100;
+
+        List<Restaurant> result = kakaoMapRestaurantFinder.findNearBy(latitude, longitude, radius);
+
+        assertThat(result).isNotEmpty();
+    }
+}


### PR DESCRIPTION
## 개요

외부 API(카카오맵) 응답을 서비스 계층에서 직접 사용하지 않도록 구조 개선

## 작업 유형

- [x] 기능 추가 (feat)
- [ ] 버그 수정 (fix)
- [x] 리팩토링 (refactor)
- [ ] 문서 수정 (docs)
- [x] 테스트 (test)
- [ ] 빌드/설정 (build)
- [ ] 기타 (chore)

## 변경 사항
- RestaurantFinder 인터페이스 및 KakaoMap 구현체 추가
- RestaurantService가 RestaurantFinder에 의존하도록 변경
- RestaurantFinder 통합 테스트 추가

## 테스트 여부
- [x] 로컬에서 테스트 완료
- [x] 테스트 코드 작성